### PR TITLE
 Change all fields on Address to be optional

### DIFF
--- a/vaccine_feed_ingest_schema/location.py
+++ b/vaccine_feed_ingest_schema/location.py
@@ -20,11 +20,11 @@ class Address(BaseModel):
     },
     """
 
-    street1: str
+    street1: Optional[str]
     street2: Optional[str]
-    city: str
-    state: str
-    zip: str
+    city: Optional[str]
+    state: Optional[str]
+    zip: Optional[str]
 
 
 class LatLng(BaseModel):


### PR DESCRIPTION
Having all optional fields allows normalizers to add what parts of the address are included in the source feed.