### PR TITLE
Improve testing of location schema

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,14 @@
+"""Common test utils"""
+import inspect
+
+
+def collect_existing_subclasses(module, base_class):
+    """Collect a set of class names in module that are subclasses of base_class"""
+    class_tuples = inspect.getmembers(module, inspect.isclass)
+    return set(
+        [
+            class_tuple[0]
+            for class_tuple in class_tuples
+            if issubclass(class_tuple[1], base_class)
+        ]
+    )

--- a/tests/test_vaccine_feed_ingest_schema_load.py
+++ b/tests/test_vaccine_feed_ingest_schema_load.py
@@ -1,5 +1,4 @@
 import pydantic
-
 from vaccine_feed_ingest_schema import load
 
 from .common import collect_existing_subclasses

--- a/tests/test_vaccine_feed_ingest_schema_load.py
+++ b/tests/test_vaccine_feed_ingest_schema_load.py
@@ -1,23 +1,22 @@
-import inspect
+import pydantic
 
 from vaccine_feed_ingest_schema import load
 
+from .common import collect_existing_subclasses
 
-def test_has_expected_classes():
-    class_tuples = inspect.getmembers(load, inspect.isclass)
-    classes = list(map(lambda class_tuple: class_tuple[0], class_tuples))
 
-    expected_classes = [
+def test_has_expected_schema():
+    expected = {
         "BaseModel",
         "NormalizedLocation",
         "ImportMatchAction",
         "ImportSourceLocation",
-    ]
+    }
 
-    for expected_class in expected_classes:
-        if expected_class not in classes:
-            raise KeyError(f"Expected class {expected_class} is not defined.")
+    existing = collect_existing_subclasses(load, pydantic.BaseModel)
 
-    for klass in classes:
-        if klass not in expected_classes:
-            raise KeyError(f"Extra class {klass} defined. Did you update your tests?")
+    missing = expected - existing
+    assert not missing, "Expected pydantic schemas are missing"
+
+    extra = existing - expected
+    assert not extra, "Extra pydantic schemas found. Update this test."

--- a/tests/test_vaccine_feed_ingest_schema_location.py
+++ b/tests/test_vaccine_feed_ingest_schema_location.py
@@ -1,15 +1,15 @@
-import inspect
+import enum
 
 import pydantic.error_wrappers
 import pytest
+
 from vaccine_feed_ingest_schema import location
 
+from .common import collect_existing_subclasses
 
-def test_has_expected_classes():
-    class_tuples = inspect.getmembers(location, inspect.isclass)
-    classes = list(map(lambda class_tuple: class_tuple[0], class_tuples))
 
-    expected_classes = [
+def test_has_expected_schema():
+    expected = {
         "BaseModel",
         "Address",
         "LatLng",
@@ -23,17 +23,109 @@ def test_has_expected_classes():
         "Link",
         "Source",
         "NormalizedLocation",
-    ]
+    }
 
-    for expected_class in expected_classes:
-        if expected_class not in classes:
-            raise KeyError(f"Expected class {expected_class} is not defined.")
+    existing = collect_existing_subclasses(location, pydantic.BaseModel)
 
-    for klass in classes:
-        if klass not in expected_classes:
-            raise KeyError(f"Extra class {klass} defined. Did you update your tests?")
+    missing = expected - existing
+    assert not missing, "Expected pydantic schemas are missing"
+
+    extra = existing - expected
+    assert not extra, "Extra pydantic schemas found. Update this test."
 
 
 def test_raises_on_invalid_location():
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         location.NormalizedLocation()
+
+    with pytest.raises(pydantic.error_wrappers.ValidationError):
+        location.NormalizedLocation(
+            id="source:id",
+            access=location.Access(drive="available"),
+            source=location.Source(
+                source="source",
+                id="id",
+                data={"id": "id"},
+            ),
+        )
+
+
+def test_valid_location():
+    # Minimal record
+    assert location.NormalizedLocation(
+        id="source:id",
+        source=location.Source(
+            source="source",
+            id="id",
+            data={"id": "id"},
+        ),
+    )
+
+    # Full record with str enums
+    assert location.NormalizedLocation(
+        id="source:id",
+        name="name",
+        address=location.Address(
+            street1="1991 Mountain Boulevard",
+            street2="#1",
+            city="Oakland",
+            state="CA",
+            zip="94611",
+        ),
+        location=location.LatLng(
+            latitude=37.8273167,
+            longitude=-122.2105179,
+        ),
+        contact=[
+            location.Contact(
+                contact_type="booking",
+                phone="(916) 445-2841",
+            )
+        ],
+        languages=["en"],
+        opening_dates=[
+            location.OpenDate(
+                opens="2021-04-01",
+                closes="2021-04-01",
+            ),
+        ],
+        opening_hours=[
+            location.OpenHour(
+                day="monday",
+                open="08:00",
+                closes="14:00",
+            ),
+        ],
+        availability=location.Availability(
+            drop_in=False,
+            appointments=True,
+        ),
+        inventory=[
+            location.Vaccine(
+                vaccine="moderna",
+                supply_level="in_stock",
+            ),
+        ],
+        access=location.Access(
+            walk=True,
+            drive=False,
+            wheelchair="partial",
+        ),
+        parent_organization=location.Organization(
+            id="rite_aid",
+            name="Rite Aid",
+        ),
+        links=[
+            location.Link(
+                authority="google_places",
+                id="abc123",
+            ),
+        ],
+        notes=["note"],
+        active=True,
+        source=location.Source(
+            source="source",
+            id="id",
+            data={"id": "id"},
+        ),
+    )

--- a/tests/test_vaccine_feed_ingest_schema_location.py
+++ b/tests/test_vaccine_feed_ingest_schema_location.py
@@ -1,8 +1,5 @@
-import enum
-
 import pydantic.error_wrappers
 import pytest
-
 from vaccine_feed_ingest_schema import location
 
 from .common import collect_existing_subclasses


### PR DESCRIPTION
1. Standardized tests to check for class exports to only check pydantic, and support checking enums when we do that later.
2. Add minimal and full normalized locations to validate with full objects.