### PR TITLE
Validate that Contact has exactly one value

### DIFF
--- a/tests/test_vaccine_feed_ingest_schema_location.py
+++ b/tests/test_vaccine_feed_ingest_schema_location.py
@@ -54,6 +54,26 @@ def test_has_expected_enums():
     assert not extra, "Extra enum found. Update this test."
 
 
+def test_valid_contact():
+    assert location.Contact(
+        contact_type=location.ContactType.BOOKING,
+        email="vaccine@example.com",
+    )
+    assert location.Contact(website="https://example.com")
+    assert location.Contact(phone="(510) 555-5555")
+
+
+def test_raises_on_invalid_contact():
+    with pytest.raises(pydantic.error_wrappers.ValidationError):
+        location.Contact(contact_type=location.ContactType.GENERAL)
+
+    with pytest.raises(pydantic.error_wrappers.ValidationError):
+        location.Contact(contact_type="invalid", email="vaccine@example.com")
+
+    with pytest.raises(pydantic.error_wrappers.ValidationError):
+        location.Contact(email="vaccine@example.com", website="https://example.com")
+
+
 def test_raises_on_invalid_location():
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         location.NormalizedLocation()

--- a/vaccine_feed_ingest_schema/location.py
+++ b/vaccine_feed_ingest_schema/location.py
@@ -8,7 +8,7 @@ import enum
 import re
 from typing import List, Optional, Union
 
-from pydantic import AnyUrl, EmailStr, Field, HttpUrl
+from pydantic import AnyUrl, EmailStr, Field, HttpUrl, root_validator
 
 from .common import BaseModel
 
@@ -194,6 +194,22 @@ class Contact(BaseModel):
     website: Optional[HttpUrl]
     email: Optional[EmailStr]
     other: Optional[str]
+
+    @root_validator
+    def validate_has_one_value(cls, values: dict) -> dict:
+        oneof_fields = ["phone", "website", "email", "other"]
+        has_values = [key for key in oneof_fields if values.get(key)]
+
+        if len(has_values) > 1:
+            raise ValueError(
+                f"Multiple values specified in {', '.join(has_values)}. "
+                "Only one value should be specified per Contact entry."
+            )
+
+        if not has_values:
+            raise ValueError("No values specified for Contact.")
+
+        return values
 
 
 class OpenDate(BaseModel):

--- a/vaccine_feed_ingest_schema/location.py
+++ b/vaccine_feed_ingest_schema/location.py
@@ -196,6 +196,7 @@ class Contact(BaseModel):
     other: Optional[str]
 
     @root_validator
+    @classmethod
     def validate_has_one_value(cls, values: dict) -> dict:
         oneof_fields = ["phone", "website", "email", "other"]
         has_values = [key for key in oneof_fields if values.get(key)]


### PR DESCRIPTION
Enforce that we encode contacts as one contact value per Contact.

- Valid: `[{"phone": "(555) 555-5555"}, {"website": "https://five.com"}]`
- Invalid: `[{"phone": "(555) 555-5555", "website": "https://five.com"}]`

