### PR TITLE
Validate the id starts with source

### DIFF
--- a/tests/test_vaccine_feed_ingest_schema_location.py
+++ b/tests/test_vaccine_feed_ingest_schema_location.py
@@ -89,6 +89,16 @@ def test_raises_on_invalid_location():
             ),
         )
 
+    with pytest.raises(pydantic.error_wrappers.ValidationError):
+        location.NormalizedLocation(
+            id="invalid:id",
+            source=location.Source(
+                source="source",
+                id="id",
+                data={"id": "id"},
+            ),
+        )
+
 
 def test_valid_location():
     # Minimal record

--- a/vaccine_feed_ingest_schema/location.py
+++ b/vaccine_feed_ingest_schema/location.py
@@ -342,3 +342,23 @@ class NormalizedLocation(BaseModel):
     notes: Optional[List[str]]
     active: Optional[bool]
     source: Source
+
+    @root_validator
+    @classmethod
+    def validate_id_source(cls, values: dict) -> dict:
+        loc_id = values.get("id")
+        if not loc_id:
+            return values
+
+        source = values.get("source")
+        if not source:
+            return values
+
+        source_name = source.source
+        if not source_name:
+            return values
+
+        if not loc_id.startswith(f"{source_name}:"):
+            raise ValueError("Location ID must be prefiexed with with source name")
+
+        return values


### PR DESCRIPTION
Verify that the id is using the source name as its prefix