### PR TITLE
Add support for UUIDs in the second half of an ID

### DIFF
--- a/vaccine_feed_ingest_schema/location.py
+++ b/vaccine_feed_ingest_schema/location.py
@@ -37,7 +37,7 @@ ENUM_VALUE_RE = re.compile(r"^[a-z0-9_]+$")
 
 # Lowercase alpha-numeric and underscores with one colon
 # e.g. az_arcgis:hsdg46sj
-LOCATION_ID_RE = re.compile(r"^[a-z0-9_]+\:[a-z0-9_]+$")
+LOCATION_ID_RE = re.compile(r"^[a-z0-9_]+\:[a-z0-9_-]+$")
 
 # Source ids can have anything but a space or a colon. Those must be replaced with another character (like a dash).
 SOURCE_ID_RE = re.compile(r"^[^\s\:]+$")


### PR DESCRIPTION
Some sources use UUIDs to identify individual sites — those UUIDs should be included in our ID for that specific site, but the regex was blocking them from being included.


before, invalid — with this change, valid:
`sc_arcgis:bbd8924909264baaa1a5a1564b393063_0_b456ea0b-db46-42f4-9bbe-3df1a38e4fa8`