### PR TITLE
Add optional content_hash str field to ImportSourceLocation

### DIFF
--- a/vaccine_feed_ingest_schema/load.py
+++ b/vaccine_feed_ingest_schema/load.py
@@ -20,4 +20,5 @@ class ImportSourceLocation(BaseModel):
     latitude: Optional[float]
     longitude: Optional[float]
     import_json: NormalizedLocation
+    content_hash: Optional[str]
     match: Optional[ImportMatchAction]


### PR DESCRIPTION
https://github.com/CAVaccineInventory/vial/issues/595

This field will be calculated by ingestion and passed along to VIAL. The content hash can be used to check if the signifiant parts of the `import_json` has changed. The hash will be computed ignoring the `source` field which has timestamps.