### PR TITLE
python_requires=">=3.8"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     install_requires=["pydantic[email]"],
     extras_require={"test": ["pytest"], "lint": ["flake8", "black", "mypy", "isort"]},
     tests_require=["vaccine-feed-ingest-schema[test]"],
-    python_requires=">=3.9",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
To help us get VIAL working on an M1 Mac (Python 3.9 in Docker has trouble with some of our other dependencies)